### PR TITLE
JFrame bug

### DIFF
--- a/src/robotbuilder/MainFrame.java
+++ b/src/robotbuilder/MainFrame.java
@@ -132,8 +132,9 @@ public class MainFrame extends JFrame {
             prefs.putInt("Width", getWidth());
             prefs.putInt("Height", getHeight());
             Point location = this.getLocationOnScreen();
-            prefs.putInt("X", location.x);
-            prefs.putInt("Y", location.y);
+            boolean minimized = location.x == -32000; // jFrame (X,Y) value for a minimized screen
+            prefs.putInt("X", minimized ? 0 : location.x);
+            prefs.putInt("Y", minimized ? 0 :location.y);
             setVisible(false);
             System.exit(0);
         }


### PR DESCRIPTION
robotpy is very cool. I was playing around with the project and got hit
with a bug that we unearthed in our own modification of robot builder.
if you close RB while minimized your settings get written to the OS for
the window location to be -32000, -32000 which is a jFrame way of
saying you’re minimized resulting in your program to open off of your
screen.. figured i’d commit it in case it happens to any users of
robotpy
